### PR TITLE
Add c++11 build flags when using OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,14 @@ include_directories(${Boost_INCLUDE_DIRS})
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -static-libgcc -static-libstdc++")
 # Windows build
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -D_WIN32_WINNT=0x0501 -static -static-libgcc -static-libstdc++")
+
+# Mac build
+if(APPLE)
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+endif(APPLE)
+
 include_directories(${PROJECT_BINARY_DIR})
 
 # Add source


### PR DESCRIPTION
Detect if running on OSX, and add necessary build flags to make compile succeed.

Compile and run seemed to work for me after this, and I seemed to be able to connect (on the same box).