### PR TITLE
Replace get_io_service() with get_executor()

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -14,7 +14,7 @@ request_handler_(handler), remove_delay(delay){
 }
 
 void connection::start() {
-    m_timer = new boost::asio::deadline_timer(socket_.get_io_service());
+    m_timer = new boost::asio::deadline_timer(socket_.get_executor());
 	do_read();
 }
 


### PR DESCRIPTION
Fixes the following error when running `make`:

```
Scanning dependencies of target ogmp
[  7%] Building CXX object src/CMakeFiles/ogmp.dir/connection.cpp.o
/home/slava/ogmp_server/src/connection.cpp: In member function 'void http::server::connection::start()':
/home/slava/ogmp_server/src/connection.cpp:17:55: error: 'boost::asio::ip::tcp::socket' {aka 'class boost::asio::basic_stream_socket<boost::asio::ip::tcp>'} has no member named 'get_io_service'
   17 |     m_timer = new boost::asio::deadline_timer(socket_.get_io_service());
      |                                                       ^~~~~~~~~~~~~~
make[2]: *** [src/CMakeFiles/ogmp.dir/build.make:108: src/CMakeFiles/ogmp.dir/connection.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:134: src/CMakeFiles/ogmp.dir/all] Error 2
make: *** [Makefile:103: all] Error 2
```